### PR TITLE
increase default pool size

### DIFF
--- a/src/lhttpc.app.src
+++ b/src/lhttpc.app.src
@@ -37,6 +37,6 @@
   {mod, {lhttpc, nil}},
   %% make default pool ~ all possible ports for a single IP interface. e.g. Usual 1025-65535
   %% define your pool or other size if you want to limit it or have more IP interfaces
-  {env, [{connection_timeout, 300000}, {pool_size, 64000}]}
+  {env, [{connection_timeout, 300000}, {pool_size, 1000}]}
  ]}.
 

--- a/src/lhttpc.app.src
+++ b/src/lhttpc.app.src
@@ -30,11 +30,13 @@
 %%% @end
 {application, lhttpc,
     [{description, "Lightweight HTTP Client"},
-        {vsn, "1.3.0"},
+        {vsn, git},
         {modules, []},
         {registered, [lhttpc_manager]},
         {applications, [kernel, stdlib, ssl, crypto]},
   {mod, {lhttpc, nil}},
-  {env, [{connection_timeout, 300000}, {pool_size, 50}]}
+  %% make default pool ~ all possible ports for a single IP interface. e.g. Usual 1025-65535
+  %% define your pool or other size if you want to limit it or have more IP interfaces
+  {env, [{connection_timeout, 300000}, {pool_size, 64000}]}
  ]}.
 


### PR DESCRIPTION
Problem:
50 connections as a default max is extremely small and outdated. 

Solution:
~~make default to almost not limited for a single IP interface. ~~
make it bigger.
If consumer want to limit it or have more they still can 

@nalundgaard 