### PR TITLE
Ignore `content-length` when TE chunked is present

### DIFF
--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -786,7 +786,7 @@ read_trailers(Socket, Ssl, Trailers, Hdrs) ->
         {ok, http_eoh} ->
             {Trailers, Hdrs};
         {ok, {http_header, _, Name, _, Value}} ->
-            Header = {lhttpc_lib:maybe_atom_to_list(Name), Value},
+            Header = lhttpc_lib:canonical_header({Name, Value}),
             read_trailers(Socket, Ssl, [Header | Trailers], [Header | Hdrs]);
         {error, {http_error, Data}} ->
             erlang:error({bad_trailer, Data})

--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -80,7 +80,8 @@ header_value(Hdr, Hdrs) ->
 %% @end
 %%------------------------------------------------------------------------------
 -spec header_value(string(), headers(), term()) -> term().
-header_value(Hdr, Headers, Default) ->
+header_value(MaybeUpperHdr, Headers, Default) ->
+    Hdr = string:to_lower(MaybeUpperHdr),
     case lists:keyfind(Hdr, 1, Headers) of
         false ->
             Default;

--- a/test/lhttpc_tests.erl
+++ b/test/lhttpc_tests.erl
@@ -145,6 +145,7 @@ tcp_test_() ->
                 ?_test(connection_timeout()),
                 ?_test(suspended_manager()),
                 ?_test(chunked_encoding()),
+                ?_test(chunked_encoding_with_content_length()),
                 ?_test(partial_upload_identity()),
                 ?_test(partial_upload_identity_iolist()),
                 ?_test(partial_upload_chunked()),
@@ -485,6 +486,14 @@ suspended_manager() ->
 
 chunked_encoding() ->
     Port = start(gen_tcp, [fun chunked_response/5, fun chunked_response_t/5]),
+    chunked_encoding(Port).
+
+chunked_encoding_with_content_length() ->
+    Port = start(gen_tcp, [fun chunked_response_with_content_length/5,
+                           fun chunked_response_t_with_content_length/5]),
+    chunked_encoding(Port).
+
+chunked_encoding(Port) ->
     URL = url(Port, "/chunked"),
     {ok, FirstResponse} = lhttpc:request(URL, get, [], 50),
     ?assertEqual({200, "OK"}, status(FirstResponse)),
@@ -1070,6 +1079,40 @@ chunked_response_t(Module, Socket, _, _, _) ->
         Socket,
         "HTTP/1.1 200 OK\r\n"
         "Content-type: text/plain\r\nTransfer-Encoding: ChUnKeD\r\n\r\n"
+        "7\r\n"
+        "Again, \r\n"
+        "E\r\n"
+        "great success!\r\n"
+        "0\r\n"
+        "Trailer-1: 1\r\n"
+        "Trailer-2: 2\r\n"
+        "\r\n"
+    ).
+
+chunked_response_with_content_length(Module, Socket, _, _, _) ->
+    Module:send(
+        Socket,
+        "HTTP/1.1 200 OK\r\n"
+        "Content-type: text/plain\r\n"
+        "Content-Length: 14\r\n"
+        "Transfer-Encoding: chunked\r\n\r\n"
+        "5\r\n"
+        "Great\r\n"
+        "1\r\n"
+        " \r\n"
+        "8\r\n"
+        "success!\r\n"
+        "0\r\n"
+        "\r\n"
+    ).
+
+chunked_response_t_with_content_length(Module, Socket, _, _, _) ->
+    Module:send(
+        Socket,
+        "HTTP/1.1 200 OK\r\n"
+        "Content-type: text/plain\r\n"
+        "Content-Length: 21\r\n"
+        "Transfer-Encoding: ChUnKeD\r\n\r\n"
         "7\r\n"
         "Again, \r\n"
         "E\r\n"


### PR DESCRIPTION
Some servers return BOTH `transfer-encoding: chunked` as well as
`content-length`, which in error, but not much help for the client.
This fixes the response handling so that it ignores the
`content-length` header if `transfer-encoding: chunked` is present
in the response, which makes the client "work" in the presence of
such a misbehaving server.