### PR TITLE
Rfc compliant at sign handling

### DIFF
--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -228,7 +228,7 @@ split_scheme("https://" ++ HostPortPath) ->
 %% @end
 %%------------------------------------------------------------------------------
 split_credentials(CredsHostPortPath) ->
-    [CredsHostPort | Path] = string:tokens(CredsHostPortPath, "/"),
+    [CredsHostPort | Path] = re:split(CredsHostPortPath, "/", [{return, list}]),
     case string:tokens(CredsHostPort, "@") of
         [HostPort] ->
             {"", "", string:join([HostPort | Path], "/")};

--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -228,21 +228,26 @@ split_scheme("https://" ++ HostPortPath) ->
 %% @end
 %%------------------------------------------------------------------------------
 split_credentials(CredsHostPortPath) ->
-    case string:tokens(CredsHostPortPath, "@") of
-        [HostPortPath] ->
-            {"", "", HostPortPath};
-        [Creds, HostPortPath] ->
+    [CredsHostPort | Path] = string:tokens(CredsHostPortPath, "/"),
+    case string:tokens(CredsHostPort, "@") of
+        [HostPort] ->
+            {"", "", string:join([HostPort | Path], "/")};
+        [Creds, HostPort] ->
             % RFC1738 (section 3.1) says:
             % "The user name (and password), if present, are followed by a
-            % commercial at-sign "@". Within the user and password field, any ":",
+            % commercial at-sign "@", but it is only valid before the first
+            % "/".
+            % Within the user and password field, any ":",
             % "@", or "/" must be encoded."
             % The mentioned encoding is the "percent" encoding.
             case string:tokens(Creds, ":") of
                 [User] ->
                     % RFC1738 says ":password" is optional
-                    {http_uri:decode(User), "", HostPortPath};
+                    {http_uri:decode(User), "",
+                     string:join([HostPort | Path], "/")};
                 [User, Passwd] ->
-                    {http_uri:decode(User), http_uri:decode(Passwd), HostPortPath}
+                    {http_uri:decode(User), http_uri:decode(Passwd),
+                     string:join([HostPort | Path], "/")}
             end
     end.
 

--- a/test/lhttpc_lib_tests.erl
+++ b/test/lhttpc_lib_tests.erl
@@ -176,6 +176,16 @@ parse_url_test_() ->
                       lhttpc_lib:parse_url("http://joe%3aarm:erlang%2Fotp@host:180/foo/bar")),
 
         ?_assertEqual(#lhttpc_url{
+                         host = "host",
+                         port = 80,
+                         path = "/foo?bar=joe@moose.nu",
+                         is_ssl = false,
+                         user = "",
+                         password = ""
+                        },
+                      lhttpc_lib:parse_url("http://host/foo?bar=joe@moose.nu")),
+
+        ?_assertEqual(#lhttpc_url{
                          host = "::1",
                          port = 80,
                          path = "/foo/bar",

--- a/test/lhttpc_lib_tests.erl
+++ b/test/lhttpc_lib_tests.erl
@@ -76,6 +76,26 @@ parse_url_test_() ->
 
         ?_assertEqual(#lhttpc_url{
                          host = "host",
+                         port = 443,
+                         path = "/foo",
+                         is_ssl = true,
+                         user = "",
+                         password = ""
+                        },
+                      lhttpc_lib:parse_url("https://host/foo")),
+
+        ?_assertEqual(#lhttpc_url{
+                         host = "host",
+                         port = 443,
+                         path = "/foo/",
+                         is_ssl = true,
+                         user = "",
+                         password = ""
+                        },
+                      lhttpc_lib:parse_url("https://host/foo/")),
+
+        ?_assertEqual(#lhttpc_url{
+                         host = "host",
                          port = 180,
                          path = "/",
                          is_ssl = false,


### PR DESCRIPTION
We started seeing urls with at-signs in the url-path and lhttpc can't handle that.

This branch adds a failing test on a RFC-compliant url, and then fixes the bug.

Details in RFC1738 §3.1.
