### PR TITLE
Handle {error, already_exists} when  processes try to add the same pool

### DIFF
--- a/src/lhttpc_manager.erl
+++ b/src/lhttpc_manager.erl
@@ -225,7 +225,9 @@ ensure_call(Pool, Pid, Host, Port, Ssl, Options) ->
                     case lhttpc:add_pool(Pool, ConnTimeout, PoolMaxSize) of
                         {ok, _Pid} ->
                             ensure_call(Pool, Pid, Host, Port, Ssl, Options);
-                        _ ->
+                       {error, already_exists} ->
+                            ensure_call(Pool, Pid, Host, Port, Ssl, Options);
+                       _ ->
                             %% Failed to create pool, exit as expected
                             exit({noproc, Reason})
                     end;


### PR DESCRIPTION
When multiple processes make request that use_pool, all try to create the pool the second one will return {error, already_started}   that is "catched" and reported as error(noproc).

This fix handles the specific {error, already_exists} that allow to call ensure_pool (that is created by this time). 