### PR TITLE
Revert "Explicitly disable server name indication"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,37 @@
 # NOTICE
-**This project is not supported anymore.**
-It's still here just to support legacy projects that may have it as a dependency.
-It's operational (at least, for Erlang versions lower than R17)
-If you're looking for a HTTP client, we would recommend you to switch to [shotgun](https://github.com/inaka/shotgun) or [fusco](https://github.com/esl/fusco)
 
-Dependencies:
- * Erlang/OTP R13-B or newer
+**This project is not supported anymore.**
+
+It's still here just to support legacy projects that may have it as a dependency.
+It's operational (at least, for Erlang versions lower than OTP 21)
+
+If you're looking for an HTTP client, we would recommend you to switch to
+[shotgun](https://github.com/inaka/shotgun) or [fusco](https://github.com/esl/fusco)
+
+## OTP 20.1 Warning
+
+lhttpc has an issue with OTP 20.1 and a bug in the `server_name_indication` ssl option. See
+[#12](https://github.com/erlcloud/lhttpc/pull/12) and [#13](https://github.com/erlcloud/lhttpc/pull/13)
+for more details. For lhttpc users on OTP 20.x, it is recommended to upgrade to OTP 20.3 or greater
+to avoid this potential issue.
+
+## Dependencies:
+
+ * Erlang/OTP R16B03-1 or newer
    * Application compiler to build, kernel, stdlib and ssl to run
 
-Building: 
-For versions > 1.2.5, lhttpc is built using rebar. Take a look at http://bitbucket.org/basho/rebar/wiki/Home for more information. There is still a Makefile with some of the old make targets, such as all, doc, test etc. for those who prefer that. The makefile will however just call rebar.
+## Building: 
 
-Configuration: (environment variables)
- * connection_timeout: The time (in milliseconds) the client will try to
-                       kepp a HTTP/1.1 connection open. Changing this value
-                       in runtime has no effect, this can however be done
-                       through lhttpc_manager:update_connection_timeout/1.
+For versions > 1.2.5, lhttpc is built using rebar. Take a look at 
+http://bitbucket.org/basho/rebar/wiki/Home for more information. There is still
+a Makefile with some of the old make targets, such as all, doc, test etc. for those who prefer
+that. The makefile will however just call rebar.
+
+## Configuration: (environment variables)
+
+ * `connection_timeout`: The time (in milliseconds) the client will try to keep a HTTP/1.1
+   connection open. Changing this value in runtime has no effect, this can however be done through
+   `lhttpc_manager:update_connection_timeout/1`.
+ * `pool_size`: The default number of client processes to allow in an `lhttpc_manager` pool.
+   Can be overridden at pool creation time, or updated at run-time using
+   `lhttpc_manager:set_max_pool_size/2`.

--- a/src/lhttpc_sock.erl
+++ b/src/lhttpc_sock.erl
@@ -68,15 +68,7 @@
 -spec connect(host(), integer(), socket_options(), timeout(), boolean()) ->
     {ok, socket()} | {error, atom()}.
 connect(Host, Port, Options, Timeout, true) ->
-    %% Server Name Indication is this:
-    %% https://en.wikipedia.org/wiki/Server_Name_Indication
-    %%
-    %% We inject this option here because as of OTP 20, the server name is
-    %% passed back as a return value so it can be validated by the client.
-    %% We want the previous behavior which ignored the server name
-    %% indicator, so disable this.  I believe this option has existed
-    %% since R16.
-    ssl:connect(Host, Port, [ {server_name_indication, disable} | Options ], Timeout);
+    ssl:connect(Host, Port, Options, Timeout);
 connect(Host, Port, Options, Timeout, false) ->
     gen_tcp:connect(Host, Port, Options, Timeout).
 


### PR DESCRIPTION
Reverts erlcloud/lhttpc#12.

It appears that the `server_name_indication` is not actually categorically added in OTP 20, it's only added when you connect to a Hostname that isn't an IP address. The wrinkle appears to be that Erlangs 20.0.x and 20.1.x didn't understand that string IPs, e.g., `"127.0.0.1"` are not Hostnames, despite that the documentation that says this (in [ssl docs](http://erlang.org/doc/man/ssl.html)):

> `{server_name_indication, HostName :: hostname()}`
> Specify the hostname to be used in TLS Server Name Indication extension. If not specified it will default to the Host argument of connect/[3,4] unless it is of type inet:ipaddress().
> 
> The HostName will also be used in the hostname verification of the peer certificate using public_key:pkix_verify_hostname/2.
> 
> `{server_name_indication, disable}`
> Prevents the Server Name Indication extension from being sent and disables the hostname verification check public_key:pkix_verify_hostname/2

So we end up with stupid errors like `failed: {options,{{server_name_indication,"127.0.0.1"}}}`.

It looks to me like this was introduced in Erlang 20.0-rc2: [erlang/otp/commit/e9b0dbb4](https://github.com/erlang/otp/commit/e9b0dbb4a95dbc8e328f08d6df6654dcbe13db09), "ssl: Add hostname check of server certificate."

It appears that it was then fixed in Erlang OTP 20.2: [erlang/otp/commit/78a9a09a](https://github.com/erlang/otp/commit/78a9a09af9216a2dea454f561e0774e67a15c361), "Stop checking DNS name for SNI."

As @RaimoNiskanen said in the comment there (in bold below):

 > RFC 6066, Section 3: Currently, the only server names supported are
 > DNS hostnames
> ...
> __But the definition seems very diffuse, so let all strings through
> and leave it up to public_key to decide...__

Diffuse indeed.