### PR TITLE
crypto:rand_bytes/1 was removed in 20.0+

### DIFF
--- a/src/lhttpc_manager.erl
+++ b/src/lhttpc_manager.erl
@@ -267,7 +267,7 @@ init(Options) ->
         true ->
             % Make sure that the ssl random number generator is seeded
             % This was new in R13 (ssl-3.10.1 in R13B vs. ssl-3.10.0 in R12B-5)
-            apply(ssl, seed, [crypto:rand_bytes(255)]);
+            apply(ssl, seed, [crypto:strong_rand_bytes(255)]);
         false ->
             ok
     end,


### PR DESCRIPTION
```erlang
_build/default/lib/lhttpc/src/lhttpc_manager.erl:270: Warning: call to crypto:rand_bytes/1 will fail, since it was removed in 20.0; use crypto:strong_rand_bytes/1
```