### PR TITLE
Update for deprecated http_uri:decode

### DIFF
--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -212,9 +212,12 @@ format_hdrs(Headers) ->
 %% Internal functions
 %%==============================================================================
 
+% http_uri:decode was deprecated in OTP 23
 -define(PCT_DECODE(X), http_uri:decode(X)).
 -ifdef (OTP_RELEASE).
     -if(?OTP_RELEASE >= 24).
+        % uri_string:percent_decode is actually available in OTP 23.2, but
+        % there is no way to conditionally compile based on OTP minor version.
         -undef(PCT_DECODE).
         -define(PCT_DECODE(X), uri_string:percent_decode(X)).
     -endif.

--- a/src/lhttpc_lib.erl
+++ b/src/lhttpc_lib.erl
@@ -212,6 +212,14 @@ format_hdrs(Headers) ->
 %% Internal functions
 %%==============================================================================
 
+-define(PCT_DECODE(X), http_uri:decode(X)).
+-ifdef (OTP_RELEASE).
+    -if(?OTP_RELEASE >= 24).
+        -undef(PCT_DECODE).
+        -define(PCT_DECODE(X), uri_string:percent_decode(X)).
+    -endif.
+-endif.
+
 %%------------------------------------------------------------------------------
 %% @private
 %% @doc
@@ -243,10 +251,10 @@ split_credentials(CredsHostPortPath) ->
             case string:tokens(Creds, ":") of
                 [User] ->
                     % RFC1738 says ":password" is optional
-                    {http_uri:decode(User), "",
+                    {?PCT_DECODE(User), "",
                      string:join([HostPort | Path], "/")};
                 [User, Passwd] ->
-                    {http_uri:decode(User), http_uri:decode(Passwd),
+                    {?PCT_DECODE(User), ?PCT_DECODE(Passwd),
                      string:join([HostPort | Path], "/")}
             end
     end.


### PR DESCRIPTION
lhttpc uses http_uri:decode which has been deprecated since OTP 23 and will be removed in OTP 25.  This patch replaces http_uri:decode with uri_string:percent_decode for OTP 24 and above.