### PR TITLE
make default cacerts connection options

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,7 @@
-{erl_opts, [debug_info]}.
+{erl_opts, [
+    debug_info,
+    {platform_define, "^2[5-9]", cacerts}
+]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {cover_enabled, true}.

--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -162,7 +162,8 @@ execute(From, Host, Port, Ssl, Path, Method, Hdrs0, Body, Options) ->
     EffectiveTcpOptions = fix_inet_options(EffectiveTcpOptions0),
     EffectiveOptions = case Ssl of
         true ->
-            DefSslOptions = application:get_env(lhttpc, ssl_options, []),
+            DefSslOptions0 = application:get_env(lhttpc, ssl_options, []),
+            DefSslOptions = add_cacerts(DefSslOptions0),
             UserSslOptions = proplists:get_value(ssl_options, Options, []),
             EffectiveSslOpts = lists:ukeymerge(1,
                 lists:ukeysort(1, UserSslOptions),
@@ -972,3 +973,14 @@ fix_inet_options(Options) ->
                 end;
             (Option) -> {true, Option}
         end, Options).
+
+-ifdef(cacerts).
+add_cacerts(ConnOpts) ->
+    case proplists:is_defined(cacerts, ConnOpts) of
+        true -> ConnOpts;
+        false ->
+            [{cacerts, public_key:cacerts_get()} | ConnOpts]
+    end.
+-else.
+add_cacerts(ConnOpts) -> ConnOpts.
+-endif.


### PR DESCRIPTION
### Problem

Starting from otp 25 the SSL certificate verification is enabled by default. It requires cacerts option to be specified.

### Proposal

By default provide cacerts certificates installed in the system

### Other issues

aims_local has SSL configured in al_sd2 but doesn't use the proper certificate. So the SSL certificate verification has to be disabled anyway until fixed:

```erlang
    {lhttpc, [
        {ssl_options, [{verify, verify_none}]}
    ]}
```