### PR TITLE
Enable HTTPS hostname match fun by default on OTP 25+

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [
     debug_info,
-    {platform_define, "^2[5-9]", cacerts}
+    {platform_define, "^2[5-9]", cacerts},
+    {platform_define, "^2[5-9]", hostname_match_fun_https}
 ]}.
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.

--- a/src/lhttpc_client.erl
+++ b/src/lhttpc_client.erl
@@ -168,7 +168,8 @@ execute(From, Host, Port, Ssl, Path, Method, Hdrs0, Body, Options) ->
                 lists:ukeysort(1, UserSslOptions),
                 lists:ukeysort(1, DefSslOptions)
             ),
-            EffectiveSslOpts = add_cacerts(EffectiveSslOpts0),
+            EffectiveSslOpts1 = add_cacerts(EffectiveSslOpts0),
+            EffectiveSslOpts = add_default_pkix_verify_hostname_match_fun_https(EffectiveSslOpts1),
             EffectiveTcpOptions ++ EffectiveSslOpts;
         false ->
             EffectiveTcpOptions
@@ -993,4 +994,16 @@ add_cacerts(ConnOpts) ->
     end.
 -else.
 add_cacerts(ConnOpts) -> ConnOpts.
+-endif.
+
+-ifdef(hostname_match_fun_https).
+add_default_pkix_verify_hostname_match_fun_https(ConnOpts) ->
+    case proplists:get_value(customize_hostname_check, ConnOpts) of
+        undefined ->
+            [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]} | ConnOpts];
+        _ ->
+            ConnOpts
+    end.
+-else.
+add_default_pkix_verify_hostname_match_fun_https(ConnOpts) -> ConnOpts.
 -endif.


### PR DESCRIPTION
* Enable HTTPS hostname match fun by default on OTP 25+, similar to providing default cacerts

I opted to enable this by default due to (as far as I know) this library only being intended for making HTTP(s) requests. The https match fun is provided by OTP in the public_key module and has been available since OTP 21.